### PR TITLE
Remove via ir for compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,5 @@
 	url = https://github.com/risc0/risc0-ethereum
 [submodule "lib/automata-on-chain-pccs"]
 	path = lib/automata-on-chain-pccs
-	url = https://github.com/automata-network/automata-on-chain-pccs
+	url = https://github.com/EspressoSystems/automata-on-chain-pccs
+	branch = fix-via-ir

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "lib/automata-on-chain-pccs"]
 	path = lib/automata-on-chain-pccs
 	url = https://github.com/EspressoSystems/automata-on-chain-pccs
-	branch = fix-via-ir
+	branch = integration

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -150,6 +150,10 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
         bytes32 rootCaCrlHash = bytes32(journal[offset + 64:offset + 96]);
         bytes32 pckCrlHash = bytes32(journal[offset + 96:offset + 128]);
 
+        return _checkCollateralHashes(rootCaHash, tcbSigningHash, rootCaCrlHash, pckCrlHash);
+    }
+
+    function _checkCollateralHashes(bytes32 rootCaHash, bytes32 tcbSigningHash, bytes32 rootCaCrlHash, bytes32 pckCrlHash) internal view returns (bool) {
         (bool tcbSigningFound, bytes32 expectedTcbSigningHash) = pccsRouter.getCertHash(CA.SIGNING);
         if (!tcbSigningFound || tcbSigningHash != expectedTcbSigningHash) {
             return false;

--- a/contracts/verifiers/V3QuoteVerifier.sol
+++ b/contracts/verifiers/V3QuoteVerifier.sol
@@ -139,13 +139,15 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
 
         // Step 5: Signature Verification on local isv report and qereport by PCK
         bytes memory localAttestationData = abi.encodePacked(rawHeader, rawBody);
+        V3Quote memory quoteCopy = quote;
+        bytes memory rawBodyCopy = rawBody;
         success = attestationVerification(
             rawQeReport,
-            quote.authData.qeReportSignature,
+            quoteCopy.authData.qeReportSignature,
             parsedCerts[0].subjectPublicKey,
             localAttestationData,
-            quote.authData.ecdsa256BitSignature,
-            quote.authData.ecdsaAttestationKey
+            quoteCopy.authData.ecdsa256BitSignature,
+            quoteCopy.authData.ecdsaAttestationKey
         );
         if (!success) {
             return (success, bytes("Failed to verify attestation and/or qe report signatures"));
@@ -156,7 +158,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
             tee: SGX_TEE,
             tcbStatus: tcbStatus,
             fmspcBytes: bytes6(pckTcb.fmspcBytes),
-            quoteBody: rawBody,
+            quoteBody: rawBodyCopy,
             advisoryIDs: new string[](0)
         });
         serialized = serializeOutput(output);

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,6 +22,6 @@ optimizer_runs = 200
 # NOTE: Be very careful with this when deploying, because I have had issues 
 # performing contract verification
 # https://github.com/foundry-rs/foundry/issues/3507
-viaIR = true
+viaIR = false
 
 ffi = true

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,6 +22,6 @@ optimizer_runs = 200
 # NOTE: Be very careful with this when deploying, because I have had issues 
 # performing contract verification
 # https://github.com/foundry-rs/foundry/issues/3507
-viaIR = false
+viaIR = true
 
 ffi = true


### PR DESCRIPTION
Fixes to make espresso-tee-contracts compile without via-ir. Note: This only makes espresso-tee-contracts compile without via-ir and doesnt change the entire automata repo to be compatible with via-ir